### PR TITLE
Feature/canned queries pass in a list instead of dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,7 @@ TODO (madeline) fill in with link to readthedocs later
 ``` python
 >>> from granola import Cereal
 
->>> config = {
-...     "canned_queries": {
-...         "data": {
-...             "`DEFAULT`": {"1\r": "1",
-...                           "2\r": ["2a", "2b"]}
-...         }}}
+>>> config = {"command_readers":{"CannedQueries": {"data": [{"1\r": "1", "2\r": ["2a", "2b"]}]}}}
 ... mock_cereal = Cereal(config)
 
 >>> mock_cereal.write(b"2\r")

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
     "encoding": "ascii",
     "command_readers":{
       "CannedQueries": {
-        "data": {"`DEFAULT`": "granola\\tests\\data\\cereal_cmds.csv"}},
+        "data": ["granola\\tests\\data\\cereal_cmds.csv"]},
       "GettersAndSetters": {
           "default_values": {
               "my_value": "You got it"

--- a/docs/config/canned_queries.rst
+++ b/docs/config/canned_queries.rst
@@ -2,8 +2,12 @@
 Canned Queries Configuration
 =================================
 
+.. todo::
+
+    update with this to not use ```DEFAULT```
+
 To use the :mod:`Command Reader <granola.command_readers>` :class:`~granola.command_readers.CannedQueries`,
-CannedQueries"`` as a dictionary in your configuration.
+you must define ``"canned_queries"`` as a dictionary in your configuration.
 Which involves having a ``"data"`` dictionary with either file paths listed or serial commands directly defined.
 
 File Path Option
@@ -15,11 +19,11 @@ To define your serial commands with file paths
 
     {
         "CannedQueries": {
-            "data": {
-                "`DEFAULT`": "data\\fixture\\fixture_serial_cmds.csv",
-                "sdicmd 1 \\?Xc!": "data\\sensor\\teros_12_get_reading_cmds.csv",
-                "sdicmd 1": "data\\sensor\\teros_12_serial_cmds.csv"
-            }
+            "data": [
+                "data\\fixture\\fixture_serial_cmds.csv",
+                "data\\sensor\\teros_12_get_reading_cmds.csv",
+                "data\\sensor\\teros_12_serial_cmds.csv"
+            ]
         }
     }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,12 +16,7 @@ A Simple Example
 
     >>> from granola import Cereal
 
-    >>> config = {
-    ...     "canned_queries": {
-    ...         "data": {
-    ...             "`DEFAULT`": {"1\r": "1",
-    ...                           "2\r": ["2a", "2b"]}
-    ...         }}}
+    >>> config = {"command_readers":{"CannedQueries": {"data": [{"1\r": "1", "2\r": ["2a", "2b"]}]}}}
     ... mock_cereal = Cereal(config)
 
     >>> mock_cereal.write(b"2\r")

--- a/granola/__init__.py
+++ b/granola/__init__.py
@@ -3,7 +3,6 @@ from granola.breakfast_cereal import Cereal, PortNotOpenError
 from granola.command_readers import (
     BaseCommandReaders,
     CannedQueries,
-    DefaultDF,
     GettersAndSetters,
     RandomizeResponse,
     SerialCmds,
@@ -30,7 +29,6 @@ __all__ = [
     "SerialCmds",
     "Cereal",
     "MockSerial",  # deprecated
-    "DefaultDF",
     "PortNotOpenError",
     "GettersAndSetters",
     "CannedQueries",

--- a/granola/breakfast_cereal.py
+++ b/granola/breakfast_cereal.py
@@ -44,9 +44,7 @@ class Cereal(Serial):
 
         change what is below on update to not user ```DEFAULT```
 
-    A serial command is checked against a dictionary of ``SerialCmds`` for if that serial command
-    is a regex match to the keys in that dictionary. If it is, then it uses that CSV, if it doesn't,
-    it uses the a default serial command file under the key ```DEFAULT```.
+        and update args
 
     Mock serials initialization follows a 2 step process. The first is with the normal ``__init__``
     method where you pass arguments to Cereal, you can do this before your project is going,
@@ -324,8 +322,6 @@ class Cereal(Serial):
             for reader in config_command_readers:
                 readers[reader.__class__.__name__] = reader
         else:
-            # deprecation("")
-            # if not command_readers:
             command_readers = (GettersAndSetters, CannedQueries)
             for reader in command_readers:
                 cr = reader()
@@ -362,7 +358,7 @@ class Cereal(Serial):
                 for cls in config_options:
                     if isinstance(cls, str):
                         c = subclasses[cls]()
-                    elif inspect.isclass(cls):
+                    elif inspect.isclass(cls):  # initialize uninitialized class
                         c = cls()
                     else:
                         c = cls
@@ -374,7 +370,7 @@ class Cereal(Serial):
                     opts.update(options)
                     if isinstance(cls, str):
                         c = subclasses[cls](**opts)
-                    elif inspect.isclass(cls):
+                    elif inspect.isclass(cls):  # initialize uninitialized class
                         c = cls(**opts)
                     else:
                         c = cls

--- a/granola/command_readers.py
+++ b/granola/command_readers.py
@@ -8,44 +8,25 @@ import re
 from collections import OrderedDict
 from pathlib import Path
 
-import attr
 import jinja2
 import jinja2.meta
 import pandas as pd
 
+from granola.enums import RandomizeResponse, get_attribute_from_enum, validate_enum
 from granola.hooks.base_hook import wrap_in_hooks
 from granola.utils import ABC, IS_PYTHON3, SENTINEL, fixpath, load_serial_df
 
-try:
-    from enum import Enum, auto
-except ImportError:
-    from aenum import Enum, auto
-
 logger = logging.getLogger(__name__)
 
-DefaultDF = "`DEFAULT`"  # Default dataframe key
-DeprecatedDefaultDF = "_default_csv_"  # Default dataframe key
 
-
-class RandomizeResponse(Enum):
-    """Randomize response enum"""
-
-    not_randomized = auto()  # Don't randomize
-    randomized = auto()  # Randomize and replace
-    randomized_and_remove = auto()  # Randomize and remove
-
-
-@attr.s
 class SerialCmds(object):
     """
     Serial Command DataFrame container object. Required columns for DataFrame are `cmd` and `response`,
     Other columns are optional, and may or may not be used by certain Command Readers.
 
     Args:
-        data (pd.DataFrame): DataFrame containing serial command, response pairs, as well potentially other
-            columns.
-
-        --- Not currently being used ---
+        data (list[pd.DataFrame]): list of DataFrames containing serial command, response pairs,
+            as well potentially other columns.
         will_randomize_responses (RandomizeResponse): Whether the responses of each command will be
             randomized or not.
 
@@ -56,16 +37,17 @@ class SerialCmds(object):
         Config guide :ref:`Canned Queries Configuration`
     """
 
-    data = attr.ib(type=pd.DataFrame)
-    will_randomize_responses = attr.ib(
-        type=RandomizeResponse,
-        default=RandomizeResponse.not_randomized,
-    )
+    def __init__(self, data=None, will_randomize_responses=RandomizeResponse.not_randomized):
+        self.data = data if data is not None else []  # type: list[pd.DataFrame]
+        self.will_randomize_responses = get_attribute_from_enum(will_randomize_responses, "name")
+        validate_enum(self.will_randomize_responses, RandomizeResponse)
 
-    @classmethod
-    def from_file(cls, file, config_path=None, **kwargs):
+    def add_dataframe(self, df):
+        self.data.append(df)
+
+    def add_df_from_file(self, file, config_path=None, **kwargs):
         """
-        Generate a `SerialCmds` from a csv file path
+        Add a df to data from a csv file path
 
         Args:
             file (str): Path to csv file. Required
@@ -85,13 +67,12 @@ class SerialCmds(object):
         logger.debug("Canned query path %s: ", file)
         df = load_serial_df(file)
         if kwargs:
-            cls._append_extra_fields_to_df(df, **kwargs)
-        return cls(data=df)
+            self._append_extra_fields_to_df(df, **kwargs)
+        return self.add_dataframe(df)
 
-    @classmethod
-    def from_dict(cls, dic, **kwargs):
+    def add_df_from_dict(self, dic, **kwargs):
         """
-        Generate a `SerialCmds` from a dictionary of serial commands. The format for this dictionary
+        Add a df to data from a dictionary of serial commands. The format for this dictionary
         can take a few forms. It can either be expressed in a JSON configuration or passed in python
         to Cereal. Here is the most basic form, where each command is mapped directly to a single response.
 
@@ -105,19 +86,18 @@ class SerialCmds(object):
         data = []
         d = copy.deepcopy(dic)
         for cmd, value in d.items():
-            cls._transverse_dict_and_append(data, cmd, value)
+            self._transverse_dict_and_append(data, cmd, value)
         df = pd.DataFrame.from_records(data)
         if kwargs:
-            cls._append_extra_fields_to_df(df, **kwargs)
-        return cls(data=df)
+            self._append_extra_fields_to_df(df, **kwargs)
+        return self.add_dataframe(df)
 
-    @classmethod
-    def _transverse_dict_and_append(cls, data, cmd, value, **extra_fields):
+    def _transverse_dict_and_append(self, data, cmd, value, **extra_fields):
         if isinstance(value, (str, int, float)):  # End of node
-            cls._append_to_list_of_rows(data, cmd, value, **extra_fields)
+            self._append_to_list_of_rows(data, cmd, value, **extra_fields)
             return
 
-        inner_extra_fields, response = cls._extract_respose(value)
+        inner_extra_fields, response = self._extract_respose(value)
 
         if isinstance(response, (list, tuple)):
             for index, item in enumerate(response):
@@ -150,11 +130,11 @@ class SerialCmds(object):
                     }
                 else:
                     raise ValueError("Invalid JSON format for canned_queries")
-                cls._append_to_list_of_rows(data, cmd, response_, **extra_fields_)
+                self._append_to_list_of_rows(data, cmd, response_, **extra_fields_)
         else:
             response_ = response
             extra_fields_ = inner_extra_fields
-            cls._append_to_list_of_rows(data, cmd, response_, **extra_fields_)
+            self._append_to_list_of_rows(data, cmd, response_, **extra_fields_)
 
     @staticmethod
     def _extract_respose(value):
@@ -457,15 +437,16 @@ class CannedQueries(BaseCommandReaders):
 
         super(CannedQueries, self).__init__(config_path=config_path, **kwargs)
         self.data = data if data is not None else OrderedDict()
-        self.serial_cmd_files = OrderedDict()
-        self.serial_dfs = OrderedDict()
+        self.serial_df = pd.DataFrame(columns=["cmd", "response"])  # default empty df
+        serial_cmd_files_kwargs = self._extract_serial_cmd_file_kw_from_config(kwargs)
+        self.serial_cmd_file = SerialCmds(**serial_cmd_files_kwargs)
         self.serial_generator = OrderedDict()
 
-        for key, maybe_file in self.data.items():
+        for maybe_file in self.data:
             if isinstance(maybe_file, (str, Path)):
-                self.serial_cmd_files[key] = SerialCmds.from_file(maybe_file, config_path, **kwargs)
+                self.serial_cmd_file.add_df_from_file(maybe_file, config_path, **kwargs)
             elif isinstance(maybe_file, dict):
-                self.serial_cmd_files[key] = SerialCmds.from_dict(maybe_file, **kwargs)
+                self.serial_cmd_file.add_df_from_dict(maybe_file, **kwargs)
 
         self._seed_serial_dfs()
 
@@ -505,10 +486,9 @@ class CannedQueries(BaseCommandReaders):
         return next_read
 
     def _start_serial_generator(self, cmd):
-        df, serial_cmd_file = self._get_matching_df(cmd)
-        serial_df = self._filter_serial_df(df=df, cmd=cmd)  # type: pd.DataFrame
+        serial_df = self._filter_serial_df(cmd=cmd)  # type: pd.DataFrame
         if not serial_df.empty:
-            serial_df_generator = self._get_generator_from_df(serial_df, serial_cmd_file)
+            serial_df_generator = self._get_generator_from_df(serial_df, self.serial_cmd_file.will_randomize_responses)
             self.serial_generator[cmd] = serial_df_generator
 
     def _load_canned_queries(self, config_path):
@@ -519,11 +499,13 @@ class CannedQueries(BaseCommandReaders):
 
         for key, maybe_file in canned_queries.get("data", {}).items():
             if isinstance(maybe_file, (str, Path)):
-                self.serial_cmd_files[key] = SerialCmds.from_file(maybe_file, config_path, extra_fields=extra_fields)
+                self.serial_cmd_file[key] = SerialCmds.add_df_from_file(
+                    maybe_file, config_path, extra_fields=extra_fields
+                )
             elif isinstance(maybe_file, dict):
-                self.serial_cmd_files[key] = SerialCmds.from_dict(maybe_file, extra_fields=extra_fields)
+                self.serial_cmd_file[key] = SerialCmds.add_df_from_dict(maybe_file, extra_fields=extra_fields)
 
-    def _extract_serial_cmd_file_kw_from_config(self):
+    def _extract_serial_cmd_file_kw_from_config(self, kw):
         """
         extract signature of SerialCmds and recursively search `self._config` for matching
         keys ad return all found key value pairs.
@@ -535,46 +517,18 @@ class CannedQueries(BaseCommandReaders):
         kwargs = OrderedDict()
         serial_cmd_args = inspection_getargspec(SerialCmds.__init__).args
         for arg in serial_cmd_args:
-            if self._config.get(arg) is not None:
-                kwargs[arg] = self._config[arg]
-            if self._config.get("canned_queries", {}).get(arg) is not None:
-                kwargs[arg] = self._config["canned_queries"][arg]
+            if kw.get(arg) is not None:
+                kwargs[arg] = kw[arg]
+            if kw.get("canned_queries", {}).get(arg) is not None:
+                kwargs[arg] = kw["canned_queries"][arg]
         logger.debug("%s extracted SerialCmds kwargs: %s", self, kwargs)
         return kwargs
 
     def _seed_serial_dfs(self):
-        if self.serial_cmd_files:
-            self.serial_dfs = OrderedDict(
-                (key, serial_cmd_file.data) for key, serial_cmd_file in self.serial_cmd_files.items()
-            )
-        else:
-            self.serial_dfs[DefaultDF] = pd.DataFrame(columns=["cmd", "response"])
+        if self.serial_cmd_file.data:
+            self.serial_df = pd.concat(objs=[df for df in self.serial_cmd_file.data])
 
-    def _get_matching_df(self, cmd):
-        """
-        Get matching DataFrame from cmd by regex search.
-
-        Each DataFrame in `self.serial_df` has a key that is a regex corresponding to what commands
-        they map to. If that matches, return that DataFrame.
-
-        Args:
-            cmd (AnyStr): Command to compare against.
-
-        Returns:
-            Tuple[pd.DataFrame, SerialCmds]: Returns matching DataFrame,
-                otherwise it returns default values.
-
-        Raises:
-            KeyError if cmd is never found is not found in DataFrames in no DefaultDF is defined.
-        """
-        for key, df in self.serial_dfs.items():
-            not_default_df = key != DefaultDF
-            if not_default_df and re.match(key, cmd):
-                return df, self.serial_cmd_files[key]
-        return self.serial_dfs[DefaultDF], self.serial_cmd_files[DefaultDF]
-
-    @staticmethod
-    def _filter_serial_df(df, cmd):
+    def _filter_serial_df(self, cmd):
         """
         Filter DataFrame to only the commands that match the inputted command
 
@@ -588,13 +542,14 @@ class CannedQueries(BaseCommandReaders):
         Returns:
             pd.DataFrame: Filtered DataFrame.
         """
+        df = self.serial_df
         conditions = df["cmd"] == cmd
         columns = ["response"]
         serial_df = df.loc[conditions, columns]
         return serial_df
 
     @staticmethod
-    def _get_generator_from_df(df, serial_cmd_file):
+    def _get_generator_from_df(df, will_randomize_responses):
         """Create a generator for the df so that when you call next on that generator, it
         gives you the next serial command each time, and not the first one. Allowing you to
         continue through the list of serial commands. Also gives the option to randomize results.
@@ -605,16 +560,16 @@ class CannedQueries(BaseCommandReaders):
                 a straight iteration.
         """
         # TODO(madeline) only pass in randomize enum? Also clean up and make subfunctions?
-        if serial_cmd_file.will_randomize_responses == RandomizeResponse.not_randomized:
+        if will_randomize_responses == RandomizeResponse.not_randomized.name:
             for _, rows in df.iterrows():
                 yield rows["response"]
         if (
-            serial_cmd_file.will_randomize_responses == RandomizeResponse.randomized
-            or serial_cmd_file.will_randomize_responses == RandomizeResponse.randomized_and_remove
+            will_randomize_responses == RandomizeResponse.randomized_w_replacement.name
+            or will_randomize_responses == RandomizeResponse.randomize_and_remove.name
         ):
             while df.shape[0] > 0:
                 df_length = df.shape[0]
                 row = random.randint(0, df_length - 1)
                 yield df["response"].iloc[row]
-                if serial_cmd_file.will_randomize_responses == RandomizeResponse.randomized_and_remove:
+                if will_randomize_responses == RandomizeResponse.randomize_and_remove.name:
                     df = df.drop(row)

--- a/granola/enums.py
+++ b/granola/enums.py
@@ -49,6 +49,17 @@ class DocumentedEnum(Enum):
         return string
 
 
+class RandomizeResponse(DocumentedEnum):
+    """
+    The different ways to specify to randomize or not randomize your
+    :class:`~granola.command_readers.CannedQueries` response
+    """
+
+    not_randomized = "Don't randomize the response"
+    randomized_w_replacement = "Randomize with replacement"
+    randomize_and_remove = "Randomize and remove"
+
+
 class HookTypes(DocumentedEnum):
     """
     Allowed hook types for ``BaseHook`` methods or for a ``register_hook``

--- a/granola/main.py
+++ b/granola/main.py
@@ -2,7 +2,6 @@
 This module is deprecated and will be removed in version 1.0. Please use  :mod:`~granola.breakfast_cereal` instead
 """
 from granola.breakfast_cereal import Cereal
-from granola.command_readers import DefaultDF, DeprecatedDefaultDF
 from granola.utils import deprecation
 
 
@@ -29,82 +28,92 @@ class MockSerial(Cereal):
     def _check_and_normalize_config_deprecation(self, config):
         command_readers = config.setdefault("command_readers", {})
         if "canned_queries" in config:
-            deprecation(
-                "Specifically CannedQueries Command Reader through the outermost config key 'canned_queries"
-                " is deprecated. Please use the 'command_reader' section instead."
-                " See https://granola.readthedocs.io/en/latest/config/config.html for more details.",
-                "1.0",
-            )
-            # swap canned_queries for "command_readers": {"CannedQueries": ...}
-            command_readers["CannedQueries"] = config.pop("canned_queries")
-
-            cr = command_readers["CannedQueries"]
-
-            if "files" in cr:
-                deprecation("canned_queries key 'files' has been deprecated. Use the key 'data' instead.", "1.0")
-                # swap file key for data
-                cr["data"] = cr.pop("files")
-
-            if DeprecatedDefaultDF in cr.get("data", {}):
-                deprecation(
-                    "canned_queries['data'] key '_default_csv_' has been deprecated," " Use '`DEFAULT`' instead",
-                    "1.0",
-                )
-                # swap deprecated default df key for default df key
-                cr["data"][DefaultDF] = cr["data"].pop(DeprecatedDefaultDF)
+            self._check_and_normalize_canned_queries_deprecation(config, command_readers)
 
         if "getters_and_setters" in config:
-            deprecation(
-                "Specifically GettersAnd_setters Command Reader through the outermost config key"
-                " 'getters_and_setters is deprecated. Please use the 'command_reader' section instead."
-                " See https://granola.readthedocs.io/en/latest/config/config.html for more details."
-            )
-
-            # Check for old form of variable substitution pre jinja
-            getters_and_setters = config["getters_and_setters"]
-            start_not_in = "variable_start_string" not in getters_and_setters
-            end_not_in = "variable_end_string" not in getters_and_setters
-            if start_not_in and end_not_in:
-                deprecation(
-                    "'GettersAndSetters' variable declaration follows old format"
-                    "\nSwitch to using ``Cereal``, which defaults to traditional jinja2 formatting ({{ var }}),"
-                    "\nor specify explicitly your variable_start_string and variable_end_string inside"
-                    " getters and setters (ex: 'variable_start_string': '`')",
-                    "1.0",
-                )
-                # specify getters and setters variable start and end as the old way
-                getters_and_setters["variable_start_string"] = "`"
-                getters_and_setters["variable_end_string"] = "`"
-
-            # swap canned_queries for "command_readers": {"CannedQueries": ...}
-            command_readers["GettersAndSetters"] = config.pop("getters_and_setters")
-
-            getters = command_readers["GettersAndSetters"].get("getters", [])
-            for getter in getters:
-                if "getter" in getter:
-                    deprecation(
-                        "Using 'getter' key inside"
-                        " config['getters_and_setters']['getters']['getter']"
-                        "is deprecated and will be removed in a future release."
-                        "\nSwitch to using the key 'cmd' instead.",
-                        "1.0",
-                    )
-                    # swap getters key for cmd
-                    getter["cmd"] = getter.pop("getter")
-            setters = command_readers["GettersAndSetters"].get("setters", [])
-            for setter in setters:
-                if "setter" in setter:
-                    deprecation(
-                        "Using 'setter' key inside "
-                        " config['getters_and_setters']['setters']['setter']"
-                        "is deprecated and will be removed in a future release."
-                        "\nSwitch to using the key 'cmd' instead.",
-                        "1.0",
-                    )
-                    # swap setters key for cmd
-                    setter["cmd"] = setter.pop("setter")
+            self._check_and_normalize_getters_and_setters_deprecation(config, command_readers)
 
         return config
+
+    def _check_and_normalize_getters_and_setters_deprecation(self, config, command_readers):
+        deprecation(
+            "Specifically GettersAnd_setters Command Reader through the outermost config key"
+            " 'getters_and_setters is deprecated. Please use the 'command_reader' section instead."
+            " See https://granola.readthedocs.io/en/latest/config/config.html for more details."
+        )
+
+        # Check for old form of variable substitution pre jinja
+        getters_and_setters = config["getters_and_setters"]
+        start_not_in = "variable_start_string" not in getters_and_setters
+        end_not_in = "variable_end_string" not in getters_and_setters
+        if start_not_in and end_not_in:
+            deprecation(
+                "'GettersAndSetters' variable declaration follows old format"
+                "\nSwitch to using ``Cereal``, which defaults to traditional jinja2 formatting ({{ var }}),"
+                "\nor specify explicitly your variable_start_string and variable_end_string inside"
+                " getters and setters (ex: 'variable_start_string': '`')",
+                "1.0",
+            )
+            # specify getters and setters variable start and end as the old way
+            getters_and_setters["variable_start_string"] = "`"
+            getters_and_setters["variable_end_string"] = "`"
+
+            # swap canned_queries for "command_readers": {"CannedQueries": ...}
+        command_readers["GettersAndSetters"] = config.pop("getters_and_setters")
+
+        getters = command_readers["GettersAndSetters"].get("getters", [])
+        for getter in getters:
+            if "getter" in getter:
+                deprecation(
+                    "Using 'getter' key inside"
+                    " config['getters_and_setters']['getters']['getter']"
+                    "is deprecated and will be removed in a future release."
+                    "\nSwitch to using the key 'cmd' instead.",
+                    "1.0",
+                )
+                # swap getters key for cmd
+                getter["cmd"] = getter.pop("getter")
+        setters = command_readers["GettersAndSetters"].get("setters", [])
+        for setter in setters:
+            if "setter" in setter:
+                deprecation(
+                    "Using 'setter' key inside "
+                    " config['getters_and_setters']['setters']['setter']"
+                    "is deprecated and will be removed in a future release."
+                    "\nSwitch to using the key 'cmd' instead.",
+                    "1.0",
+                )
+                # swap setters key for cmd
+                setter["cmd"] = setter.pop("setter")
+
+    def _check_and_normalize_canned_queries_deprecation(self, config, command_readers):
+        deprecation(
+            "Specifically CannedQueries Command Reader through the outermost config key 'canned_queries"
+            " is deprecated. Please use the 'command_reader' section instead."
+            " See https://granola.readthedocs.io/en/latest/config/config.html for more details.",
+            "1.0",
+        )
+        # swap canned_queries for "command_readers": {"CannedQueries": ...}
+        command_readers["CannedQueries"] = config.pop("canned_queries")
+
+        cr = command_readers["CannedQueries"]
+
+        if "files" in cr:
+            deprecation("canned_queries key 'files' has been deprecated. Use the key 'data' instead.", "1.0")
+            # swap file key for data
+            cr["data"] = cr.pop("files")
+
+        data = cr.get("data", [])
+        if isinstance(data, dict):
+            deprecation(
+                "canned_queries['data'] as a dictionary has been deprecated."
+                "\nEither use a list of files or list of dictionaries of cmds and responses instead"
+                "See configuration section of documentation.",
+                "1.0",
+            )
+            # Turn dictionary of keys mapped to their values into just a list
+            new_data = [value for value in data.values()]
+            cr["data"] = new_data
 
     def _check_and_normalize_command_readers_deprecations(self, config, command_readers):
         config_readers = config["command_readers"]

--- a/granola/tests/config.json
+++ b/granola/tests/config.json
@@ -55,11 +55,22 @@
                     }
                 ]
             },
-            "CannedQueries": { "data": {
-                "`DEFAULT`": "data/cereal_cmds.csv",
-                "sdicmd 1 get-measurement": "data\\sensor_get_reading_cmds.csv",
-                "sdicmd 1": "data\\sensor_cmds.csv"
-                }}
+            "CannedQueries": { "data": [
+                "data/cereal_cmds.csv",
+                "data\\sensor_get_reading_cmds.csv",
+                "data\\sensor_cmds.csv",
+                {
+                    "1\r": "1",
+                    "2\r": {"response": "2"},
+                    "3\r": {"response": "3", "delay": 3},
+                    "4\r": {"response": ["4a", "4b"]},
+                    "5\r": {"response": ["5a", "5b"], "delay": 5},
+                    "6\r": {"response": ["6a", "6b"], "delay": [6.1, 6.2]},
+                    "7\r": {"response": [["7a", {"delay": 7}], "7b"]},
+                    "8\r": {"response": [["8a", {"delay": 8.1}], "8b"], "delay": 8},
+                    "9\r": [["9a", {"delay": 9}], "9b"]
+                }
+            ]}
         }
     },
 
@@ -94,7 +105,7 @@
 
     "incorrect_getter": {
         "command_readers":{
-            "CannedQueries": {"data": {"`DEFAULT`": "data/cereal_cmds.csv"}},
+            "CannedQueries": {"data": [{"1\r": "1", "2\r": {"response": "3", "delay": 3}}]},
             "GettersAndSetters": {
                 "default_values": {
                     "sn": "42"
@@ -111,7 +122,7 @@
 
     "incorrect_setter": {
         "command_readers":{
-            "CannedQueries": {"data": {"`DEFAULT`": "data/cereal_cmds.csv"}},
+            "CannedQueries": {"data": [{"1\r": "1", "2\r": {"response": "3", "delay": 3}}]},
             "GettersAndSetters": {
                 "default_values": {
                     "sn": "42"
@@ -128,18 +139,11 @@
 
     "stick_hook": {
         "command_readers":{
-            "CannedQueries": {
-                "data": {
-                    "`DEFAULT`": "data/cereal_cmds.csv",
-                    "sdicmd 1 get-measurement": "data\\sensor_get_reading_cmds.csv",
-                    "sdicmd 1": "data\\sensor_cmds.csv"
-                }
-            }
+            "CannedQueries": {"data": [{"1\r": "1", "2\r": {"response": "3", "delay": 3}}]}
         },
         "hooks": {
             "StickCannedQueries": {
-                "hook_type": "",
-                "attributes": ["get -volt\r"],
+                "attributes": ["2\r"],
                 "include_or_exclude": "exclude"
             }
         }
@@ -147,24 +151,19 @@
 
     "command_readers": {
         "command_readers": {
-            "CannedQueries": {
-                "data": {
-                    "`DEFAULT`": "data/cereal_cmds.csv",
-                    "sdicmd 1 get-measurement": "data\\sensor_get_reading_cmds.csv",
-                    "sdicmd 1": "data\\sensor_cmds.csv"
-                }
-            }
+            "CannedQueries": {"data": ["data/cereal_cmds.csv"]}
         }
     },
 
     "dictionary": {
         "command_readers":{
             "CannedQueries": {
-                "data": {
-                    "`DEFAULT`": {"get -temp\r": {"response": ["20\r>",
-                                                            "22\r>"]},
-                                "get -sn\r": "sn1234\r>",
-                                "test -off\r": {"response": "OK\r>"}}}
+                "data": [
+                    {"get -temp\r": {"response": ["20\r>",
+                                                  "22\r>"]},
+                     "get -sn\r": "sn1234\r>",
+                     "test -off\r": {"response": "OK\r>"}}
+                ]
             }
         }
     },

--- a/granola/tests/conftest.py
+++ b/granola/tests/conftest.py
@@ -27,6 +27,15 @@ def assert_filled_any(mask):
     assert mask.any()
 
 
+def all_equal(iterator):
+    iterator = iter(iterator)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return True
+    return all(first == x for x in iterator)
+
+
 def query_device(bk_cereal, cmd):
     bk_cereal.write(("{cmd}\r".format(cmd=cmd)).encode(bk_cereal._encoding))
     return bk_cereal.read(1000)
@@ -108,8 +117,8 @@ def mock_read():
 def canned_queries_command_readers():
     command_readers = {
         "CannedQueries": {
-            "data": {
-                "`DEFAULT`": {
+            "data": [
+                {
                     "1\r": "1",
                     "2\r": {"response": "2"},
                     "3\r": {"response": "3", "delay": 3},
@@ -120,7 +129,7 @@ def canned_queries_command_readers():
                     "8\r": {"response": [["8a", {"delay": 8.1}], "8b"], "delay": 8},
                     "9\r": [["9a", {"delay": 9}], "9b"],
                 }
-            },
+            ],
             "delay": 0,
         }
     }

--- a/granola/tests/conftest.py
+++ b/granola/tests/conftest.py
@@ -1,6 +1,5 @@
 import functools
 import os
-import warnings
 
 import pytest
 
@@ -52,10 +51,10 @@ def check_deprecation(*msgs):
 
         @functools.wraps(func)
         def _inner(*args, **kwargs):
-            with warnings.catch_warnings(record=True) as w:
+            with pytest.deprecated_call() as dep:
                 r = func(*args, **kwargs)
-                assert issubclass(w[-1].category, Warning)
-                assert msg in str(w[-1].message).lower()
+                assert issubclass(dep.list[-1].category, Warning)
+                assert msg in str(dep.list[-1].message).lower()
             return r
 
         return _inner

--- a/granola/tests/serial_tests/test_canned_queries.py
+++ b/granola/tests/serial_tests/test_canned_queries.py
@@ -42,3 +42,17 @@ def test_multipart_writes_with_canned_queries_only_fire_on_carriage_return(mock_
 
     # Then the correct result,and only the correct result is returned
     assert mock_cereal.read(1000) == output
+
+
+def test_that_you_can_use_both_files_and_dictionary_of_cmds_and_response_in_same_config(mock_cereal):
+    # Given a mock cerial device that has canned queries defined a both paths to csvs and dictionaries
+    # of cmds and responses
+
+    # When we query from a command from one of the files
+    ok = query_device(mock_cereal, "reset")
+    # one we query from a command from the dictionary of cmds
+    one = query_device(mock_cereal, "1")
+
+    # Then they both return the correct response
+    assert ok == b"OK\r>"
+    assert one == b"1"

--- a/granola/tests/test_deprecations.py
+++ b/granola/tests/test_deprecations.py
@@ -32,7 +32,10 @@ def test_mock_serial_deprecation():
         assert new_sn + "\r>" == decoded_sn
 
 
-@check_deprecation("canned_queries['data'] key '_default_csv_' has been deprecated")
+@check_deprecation(
+    "canned_queries['data'] as a dictionary has been deprecated."
+    "\nEither use a list of files or list of dictionaries of cmds and responses instead"
+)
 def test_default_df_key_deprecation():
     # Given a mock serial with deprecated "files" and "_default_csv_" keys
     mock = MockSerial("deprecated", CONFIG_PATH_DEPRECATIONS)

--- a/granola/tests/test_serial_cmd_obj.py
+++ b/granola/tests/test_serial_cmd_obj.py
@@ -1,5 +1,12 @@
-from granola import Cereal
-from granola.tests.conftest import CONFIG_PATH, assert_filled_all, query_device
+import pandas as pd
+
+from granola import CannedQueries, Cereal, RandomizeResponse
+from granola.tests.conftest import (
+    CONFIG_PATH,
+    all_equal,
+    assert_filled_all,
+    query_device,
+)
 
 
 def test_that_you_can_pass_canned_queries_directly_instead_of_as_file_paths(canned_queries_command_readers):
@@ -68,13 +75,13 @@ def test_that_you_can_specify_a_delay_on_one_command():
     # Given a dictionary canned queries with a delay on only one command
     command_readers = {
         "CannedQueries": {
-            "data": {"`DEFAULT`": {"1\r": "1", "2\r": {"response": "3", "delay": 3}}},
+            "data": [{"1\r": "1", "2\r": {"response": "3", "delay": 3}}],
         }
     }
 
     # When we initialize it
     mock = Cereal(command_readers=command_readers)()
-    df = mock._readers_["CannedQueries"].serial_dfs["`DEFAULT`"]
+    df = mock._readers_["CannedQueries"].serial_df
 
     # Then 2 has a delay of 3 but get -sn does not have any delay (nan)
     assert_filled_all(df.loc[(df.cmd == "2\r")]["delay"] == 3)
@@ -88,7 +95,7 @@ def test_that_you_can_specify_a_delay_on_one_command_and_a_broadcasting_delay_fo
 
     # When we initialize it
     mock = Cereal(command_readers=canned_queries_command_readers)()
-    df = mock._readers_["CannedQueries"].serial_dfs["`DEFAULT`"]
+    df = mock._readers_["CannedQueries"].serial_df
 
     # Then 3 gets the default delay of 3, but 2 has a delay of 0 since we that is the default
     assert_filled_all(df.loc[(df.cmd == "3\r")]["delay"] == 3)
@@ -100,7 +107,7 @@ def test_that_you_can_specify_a_inside_a_response_list(canned_queries_command_re
 
     # When we initialize it
     mock = Cereal(command_readers=canned_queries_command_readers)()
-    df = mock._readers_["CannedQueries"].serial_dfs["`DEFAULT`"]
+    df = mock._readers_["CannedQueries"].serial_df
 
     # THen the delays inside lists should specify columns
     assert_filled_all(df.loc[(df.cmd == "1\r")]["delay"] == 0)
@@ -116,7 +123,7 @@ def test_that_that_all_off_the_ways_to_specify_canned_queries_inside_dicts_can_g
 
     # When we initialize it
     mock = Cereal(command_readers=canned_queries_command_readers)()
-    df = mock._readers_["CannedQueries"].serial_dfs["`DEFAULT`"]
+    df = mock._readers_["CannedQueries"].serial_df
 
     # THen we should get get the delays inside lists should specify columns
     assert_filled_all(df.loc[(df.cmd == "1\r")]["delay"] == 0)
@@ -132,3 +139,59 @@ def test_that_that_all_off_the_ways_to_specify_canned_queries_inside_dicts_can_g
     assert_filled_all(df.loc[(df.cmd == "8\r") & (df.response == "8b")]["delay"] == 8)
     assert_filled_all(df.loc[(df.cmd == "9\r") & (df.response == "9a")]["delay"] == 9)
     assert_filled_all(df.loc[(df.cmd == "9\r") & (df.response == "9b")]["delay"] == 0)
+
+
+def test_random_responses():
+    # When we have a dataframe and and randomized response enum
+    df = pd.DataFrame(data=dict(cmd=[1, 2, 3], response=[1, 2, 3]))
+    will_randomize_responses = RandomizeResponse.randomized_w_replacement.name
+
+    # When we randomize our response 100 times
+    # (we choose 100, just to be pretty sure that it will give us difference respones, even if luck isn't on our side)
+    randomized_responses = []
+    for _ in range(100):
+        randomized_responses.append(next(CannedQueries._get_generator_from_df(df.copy(), will_randomize_responses)))
+
+    # instead of always getting the 1st response, we should get others as well
+    assert len(set(randomized_responses)) != 1
+
+
+def test_random_responses_with_removal():
+
+    # When we have a dataframe and and randomized response enum
+    df = pd.DataFrame(data=dict(cmd=[1, 2, 3], response=[1, 2, 3]))
+    will_randomize_responses = RandomizeResponse.randomize_and_remove.name
+
+    # When we randomize our response 100 times
+    # (we choose 100, just to be pretty sure that it will give us difference respones, even if luck isn't on our side)
+    randomized_responses = []
+    for _ in range(100):
+        responses = []
+        for _ in range(len(df)):
+            responses.append(next(CannedQueries._get_generator_from_df(df.copy(), will_randomize_responses)))
+        randomized_responses.append(responses)
+
+    # instead of always getting the 1st response, we should get others as well
+    for responses in randomized_responses:
+        assert len(responses) == 3
+    assert not all_equal(randomized_responses)
+
+
+def test_pass_in_randomize_response_in_canned_queries():
+    # Given a CannedQueries config with a randomized responses
+    command_readers = {
+        "CannedQueries": {"data": [{"1\r": ["1a", "1b", "1c"]}], "will_randomize_responses": "randomized_w_replacement"}
+    }
+
+    # When we query the entire list of our 1\r command 100 times
+    # (we choose 100, just to be pretty sure that it will give us difference respones, even if luck isn't on our side)
+    randomized_responses = []
+    for _ in range(100):
+        mock = Cereal(command_readers=command_readers)()
+        responses = []
+        for _ in range(3):
+            responses.append(query_device(mock, "1"))
+        randomized_responses.append(responses)
+
+    # Then the order the 3 respones is not the same accross all 100 tries
+    assert not all_equal(randomized_responses)


### PR DESCRIPTION
## Description

For CannedQueries, change from passing in a dictionaries mapping serial command regexes to files or dicts which turn into data frames to just a list of files or dicts, which get concatenated into just one dataframe. All serial commands come in and create a sub df of just the matching serial command, so the seperating them out was just extra complexity that didn't need to be there and add more to maintain later.

Also, finally change the code to actually allow the usage of the randomizing response again. It used to be allowed, then something broke it, so we just disabled it, and now it works again. So yay!


<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.