### PR TITLE
Override reconfigure port for mocked cereal

### DIFF
--- a/granola/breakfast_cereal.py
+++ b/granola/breakfast_cereal.py
@@ -338,6 +338,10 @@ class Cereal(Serial):
             Should only be used with pyserial versions >= 3.0"""
             self._clear_output()
 
+        def _reconfigure_port(self):
+            """Bypassing pyserial's reconfigure port"""
+            pass
+
         @property
         def in_waiting(self):
             """mocking pyserial's in_waiting"""
@@ -370,6 +374,10 @@ class Cereal(Serial):
             """mocking pyserial's outWaiting"""
             return self._out_waiting
 
+        def _reconfigurePort(self):
+            """Bypassing pyserial's reconfigure port"""
+            pass
+
     @property
     def _is_open(self):
         """internal is_open so we always return the right version depending on what pyserial we have"""
@@ -397,9 +405,6 @@ class Cereal(Serial):
 
     def _clear_output(self):
         self._next_write = ""
-
-    def _reconfigure_port(self):
-        pass
 
     @property
     def _in_waiting(self):

--- a/granola/breakfast_cereal.py
+++ b/granola/breakfast_cereal.py
@@ -398,6 +398,9 @@ class Cereal(Serial):
     def _clear_output(self):
         self._next_write = ""
 
+    def _reconfigure_port(self):
+        pass
+
     @property
     def _in_waiting(self):
         return len(self._next_read)

--- a/granola/tests/serial_tests/test_cereal_attributes.py
+++ b/granola/tests/serial_tests/test_cereal_attributes.py
@@ -107,3 +107,15 @@ def test_flush_output(mock_cereal):
 
     # Then write buffer is cleared
     assert mock_cereal._next_write == ""
+
+
+def test_reconfigure_port(mock_cereal):
+    # Given a mock serial device, open the port
+    mock_cereal.open()
+    assert mock_cereal.is_open
+
+    # When an attribute is called that pySerial internally reconfigures the port
+    mock_cereal.baudrate = 57600
+
+    # Then the call is successful
+    assert mock_cereal.baudrate == 57600


### PR DESCRIPTION
## Description

This is to address an issue where changing attributes such as the timeout, baudrate, etc. cause an exception when called
with a `cereal` object.

- Adds an override to pySerial's private `_reconfigure_port` method, to bypass pySerial attempting to configure hardware with `cereal`.
- Test confirms that override works, removing the override will result in the call failing in pySerial's `_reconfigure_port` method.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/metergroup/GRANOLA/blob/main/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`]https://github.com/metergroup/GRANOLA/blob/main/CONTRIBUTING.md) guide.
- [X] I've written tests for all new methods and classes that I created.
- [X] I've written the docstring in `Google` format for all the methods and classes that I used.
- [X] I've updated the code style using `invoke style`, and checked all my tests with `invoke pytest` or I have ran `invoke all` to accomplish both.